### PR TITLE
Added LSB Tags

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -9,6 +9,15 @@
 
 		var daemonTemplate = [
 			'#!/bin/bash'
+		,	'### BEGIN INIT INFO'
+		,	'# Provides:          {{app}}'
+		,	'# Required-Start:    $remote_fs $syslog'
+		,	'# Required-Stop:     $remote_fs $syslog'
+		,	'# Default-Start:     2 3 4 5'
+		,	'# Default-Stop:      0 1 6'
+		,	'# Short-Description: forever running {{app}}'
+		,	'# Description:       {{app}}'
+		,	'### END INIT INFO'
 		,	'#'
 		,	'# initd a node app'
 		,	'# Based on a script posted by https://gist.github.com/jinze at https://gist.github.com/3748766'


### PR DESCRIPTION
Added LSB Tags (Provides, Description, etc.) to the template to stop Debian from complaining everytime a generated script is used with update-rc.d
