### PR TITLE
add command option, so you can run things like coffee --nodejs --harmony

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -26,9 +26,10 @@
 		,	'# Source function library.'
 		,	'. /lib/lsb/init-functions'
 		,	''
-		,	'pidFile={{pidfile}}' 
-		,	'logFile={{logfile}}' 
+		,	'pidFile={{pidfile}}'
+		,	'logFile={{logfile}}'
 		,	''
+		,	'command={{command}}'
 		,	'nodeApp={{app}}'
 		,	''
 		,	'start() {'
@@ -36,15 +37,15 @@
 		,	''
 		,	'	# This is found in the library referenced at the top of the script'
 		,	' 	start_daemon'
-		,	''		    
+		,	''
 		,	'	# Notice that we change the PATH because on reboot'
 		,	'   # the PATH does not include the path to node.'
 		,	'   # Launching forever with a full path'
 		,	'   # does not work unless we set the PATH.'
 		,	'   PATH=/usr/local/bin:$PATH'
 		,	'	export NODE_ENV={{env}}'
-		,	'   #PORT=80' 
-		,	'   forever start --pidFile $pidFile -l $logFile -a -d $nodeApp'
+		,	'   #PORT=80'
+		,	'   forever start --pidFile $pidFile -l $logFile -a -d -c "$command" $nodeApp'
 		,	'   RETVAL=$?'
 		,	'}'
 		,	''
@@ -125,14 +126,18 @@
 						this.packageInfo.info = true;
 						this.packageInfo.name = package.name;
 						this.packageInfo.appjs = package.main;
+						if(package.scripts && package.scripts.start){
+							this.packageInfo.command = package.scripts.start;
+						}
 					}
 				}
 				catch(err) {}
-			
-				// Create default options value	
+
+				// Create default options value
 				this.options = {	app: path.join(process.cwd() + '/' + this.packageInfo.appjs),
 									env:'production',
 									name:this.packageInfo.name,
+									command:this.packageInfo.command,
 									logfile:'/var/run/' + this.packageInfo.name + '.log',
 									pidfile:'/var/run/' + this.packageInfo.name + '.pid',
 									monit:'3000'
@@ -140,8 +145,9 @@
 
 				// Create options parsing
 				program
-					.version('0.1.0')
-					.option('-a, --app [path]', 'Path to node.js main js file')
+					.version('0.1.1')
+					.option('-a, --app [path]', 'Path to node.js main file')
+					.option('-c, --command [value]', 'Command to execute on main file')
 					.option('-e, --env [value]', 'Export NODE_ENV with value')
 					.option('-l, --logfile [path]', 'Logs the daemon output to LOGFILE')
 					.option('-n, --name [value]', 'Application name')
@@ -199,6 +205,10 @@
 
 				if(program.app)
 					this.options.app = program.app;
+				if(program.command)
+				  this.options.command = program.command;
+				else
+					this.options.command = 'node'
 				if(program.name)
 					this.options.name = program.name;
 				if(program.env)


### PR DESCRIPTION
this reads in any start scripts if you have them
