### PR TITLE
lib/main.js: Ensure newline at end of generated files

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -101,6 +101,7 @@
 		,	'        ;;'
 		,	'esac'
 		,	'exit $RETVAL'
+		,	''
 		].join('\n');
 
 
@@ -112,6 +113,7 @@
 		,	'    	request /'
 		,	'        with timeout 10 seconds'
 		,	'        then restart'
+		,	''
 		].join('\n');
 
 


### PR DESCRIPTION
Currently, a newline is missing at the end of the generated files.

Fixes: #16